### PR TITLE
[SPEC] Remove allow_no_indices from indices.upgrade

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
@@ -12,10 +12,6 @@
         }
       },
       "params": {
-        "allow_no_indices": {
-            "type" : "boolean",
-            "description" : "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
-        },
         "expand_wildcards": {
             "type" : "enum",
             "options" : ["open","closed","none","all"],


### PR DESCRIPTION
Speaking with @s1monw it's not used, and specifying it results in `unrecognized parameter: [allow_no_indices]`.

I'm not sure if there are other APIs where it has been removed?  Also applies to `5.x`
